### PR TITLE
feat: add basic-api example

### DIFF
--- a/basic-api/.gitignore
+++ b/basic-api/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/basic-api/README.md
+++ b/basic-api/README.md
@@ -1,0 +1,110 @@
+# Basic API Example
+
+A complete example demonstrating all core features of the Bunary framework.
+
+## Features Demonstrated
+
+- ✅ **Route Definition** - Using `Router` to define HTTP endpoints
+- ✅ **Path Parameters** - `:id` syntax for dynamic route segments
+- ✅ **Query Parameters** - Accessing query string values
+- ✅ **JSON Serialization** - Automatic JSON response handling
+- ✅ **Middleware Pipeline** - Logging and CORS middleware
+- ✅ **Environment Helpers** - `env()`, `isDev()` for configuration
+
+## Quick Start
+
+```bash
+# Install dependencies
+bun install
+
+# Start development server (with hot reload)
+bun run dev
+
+# Or build and run production
+bun run build
+bun run start
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Welcome message with environment info |
+| GET | `/health` | Health check endpoint |
+| GET | `/users/:id` | Get user by ID (path params) |
+| GET | `/users/:userId/posts/:postId` | Get post (multiple path params) |
+| GET | `/items?page=1&limit=10` | List items with pagination (query params) |
+| POST | `/resources` | Create a new resource |
+| PUT | `/resources/:id` | Update a resource |
+| DELETE | `/resources/:id` | Delete a resource |
+
+## Example Requests
+
+```bash
+# Welcome
+curl http://localhost:3000/
+
+# Health check
+curl http://localhost:3000/health
+
+# Get user by ID
+curl http://localhost:3000/users/123
+
+# Get post by user and post ID
+curl http://localhost:3000/users/1/posts/42
+
+# List items with pagination
+curl "http://localhost:3000/items?page=2&limit=5&search=test"
+
+# Create resource
+curl -X POST http://localhost:3000/resources \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Resource", "type": "example"}'
+
+# Update resource
+curl -X PUT http://localhost:3000/resources/abc123 \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Updated Resource"}'
+
+# Delete resource
+curl -X DELETE http://localhost:3000/resources/abc123
+```
+
+## Project Structure
+
+```
+basic-api/
+├── package.json          # Dependencies and scripts
+├── bunary.config.ts      # Bunary configuration
+├── src/
+│   └── index.ts          # Application entry point
+└── README.md             # This file
+```
+
+## Configuration
+
+The `bunary.config.ts` file uses `defineConfig()` for type-safe configuration:
+
+```typescript
+import { defineConfig } from "@bunary/core";
+
+export default defineConfig({
+  app: {
+    name: "basic-api",
+    env: "development",
+  },
+});
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | Server port |
+| `APP_ENV` | `development` | Application environment |
+
+## Learn More
+
+- [@bunary/core](https://github.com/bunary-dev/core) - Core utilities and configuration
+- [@bunary/http](https://github.com/bunary-dev/http) - HTTP routing and middleware
+- [Bunary Documentation](https://github.com/bunary-dev) - Full framework docs

--- a/basic-api/bun.lock
+++ b/basic-api/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "basic-api",
+      "dependencies": {
+        "@bunary/core": "^0.0.2",
+        "@bunary/http": "^0.0.2",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.6",
+      },
+    },
+  },
+  "packages": {
+    "@bunary/core": ["@bunary/core@0.0.2", "", {}, "sha512-fBJMKV1pjrVMXa/ndRehmX/cXQd71b37YGSXQ3p2DDyynvP7EDtYlWJ3V4KQa3jIC/OeYCKmjopcXDHS/IMN7Q=="],
+
+    "@bunary/http": ["@bunary/http@0.0.2", "", { "dependencies": { "@bunary/core": "^0.0.2" } }, "sha512-/6kS8PCaNXYMSE6NCFG2fKFY+4jCco7WGDk4Dw6jHssZfkLvlhOeeQAavqcFLkcRmQfIG4ALH77tG9V4va3RmA=="],
+
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
+    "@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
+
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/basic-api/bunary.config.ts
+++ b/basic-api/bunary.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@bunary/core";
+
+/**
+ * Bunary application configuration.
+ *
+ * This file configures your Bunary application using the defineConfig helper.
+ * All configuration is type-safe and validated at runtime.
+ */
+export default defineConfig({
+  app: {
+    // Application name - used in logs and identification
+    name: "basic-api",
+
+    // Environment - controls behavior like logging and error display
+    // Use env("APP_ENV", "development") in production
+    env: "development",
+  },
+});

--- a/basic-api/package.json
+++ b/basic-api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "basic-api",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Basic API example demonstrating Bunary framework features",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --target=bun --outdir=dist",
+    "start": "bun run dist/index.js"
+  },
+  "dependencies": {
+    "@bunary/core": "^0.0.2",
+    "@bunary/http": "^0.0.2"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.6"
+  }
+}

--- a/basic-api/src/index.ts
+++ b/basic-api/src/index.ts
@@ -1,0 +1,225 @@
+/**
+ * Basic API Example
+ *
+ * This example demonstrates the core features of the Bunary framework:
+ * - Route definition with createApp()
+ * - Path parameters (:id syntax)
+ * - Query parameters
+ * - JSON serialization
+ * - Middleware pipeline
+ * - Environment helpers
+ */
+
+import { env, isDev } from "@bunary/core";
+import { createApp } from "@bunary/http";
+
+// ============================================================================
+// App Creation
+// ============================================================================
+
+const app = createApp();
+
+// ============================================================================
+// Middleware Examples
+// ============================================================================
+
+/**
+ * Logging middleware
+ *
+ * Logs all incoming requests with method, path.
+ * This middleware doesn't modify the response, just logs and passes through.
+ */
+app.use(async (ctx, next) => {
+  const method = ctx.request.method;
+  const url = new URL(ctx.request.url);
+  const start = Date.now();
+
+  // Call next middleware/handler
+  const response = await next();
+
+  const duration = Date.now() - start;
+  console.log(`${method} ${url.pathname} - ${duration}ms`);
+
+  return response;
+});
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Basic Routes
+// ----------------------------------------------------------------------------
+
+/**
+ * Health check endpoint
+ * GET /health
+ *
+ * Returns the current status of the API.
+ */
+app.get("/health", () => {
+  return {
+    status: "healthy",
+    timestamp: new Date().toISOString(),
+  };
+});
+
+/**
+ * Welcome endpoint
+ * GET /
+ *
+ * Returns a welcome message with environment info.
+ */
+app.get("/", () => {
+  return {
+    message: "Welcome to Bunary!",
+    environment: isDev() ? "development" : "production",
+    docs: "/docs",
+  };
+});
+
+// ----------------------------------------------------------------------------
+// Path Parameters Example
+// ----------------------------------------------------------------------------
+
+/**
+ * Get user by ID
+ * GET /users/:id
+ *
+ * Demonstrates path parameter extraction.
+ * The :id segment is extracted and available in ctx.params.
+ */
+app.get("/users/:id", (ctx) => {
+  const userId = ctx.params.id;
+
+  // In a real app, you'd fetch from a database
+  return {
+    id: userId,
+    name: `User ${userId}`,
+    email: `user${userId}@example.com`,
+  };
+});
+
+/**
+ * Get post by user and post ID
+ * GET /users/:userId/posts/:postId
+ *
+ * Demonstrates multiple path parameters.
+ */
+app.get("/users/:userId/posts/:postId", (ctx) => {
+  const { userId, postId } = ctx.params;
+
+  return {
+    userId,
+    postId,
+    title: `Post ${postId} by User ${userId}`,
+    content: "This is a sample post content.",
+  };
+});
+
+// ----------------------------------------------------------------------------
+// Query Parameters Example
+// ----------------------------------------------------------------------------
+
+/**
+ * List items with pagination
+ * GET /items?page=1&limit=10&search=term
+ *
+ * Demonstrates query parameter handling.
+ */
+app.get("/items", (ctx) => {
+  const page = parseInt(ctx.query.get("page") || "1", 10);
+  const limit = parseInt(ctx.query.get("limit") || "10", 10);
+  const search = ctx.query.get("search") || "";
+
+  // Generate sample items
+  const items = Array.from({ length: limit }, (_, i) => ({
+    id: (page - 1) * limit + i + 1,
+    name: `Item ${(page - 1) * limit + i + 1}`,
+  }));
+
+  return {
+    page,
+    limit,
+    search: search || null,
+    total: 100,
+    items,
+  };
+});
+
+// ----------------------------------------------------------------------------
+// POST/PUT/DELETE Examples
+// ----------------------------------------------------------------------------
+
+/**
+ * Create a new resource
+ * POST /resources
+ *
+ * Demonstrates handling POST requests with JSON body.
+ */
+app.post("/resources", async (ctx) => {
+  const body = await ctx.request.json();
+
+  return new Response(
+    JSON.stringify({
+      id: crypto.randomUUID(),
+      ...body,
+      createdAt: new Date().toISOString(),
+    }),
+    {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+});
+
+/**
+ * Update a resource
+ * PUT /resources/:id
+ */
+app.put("/resources/:id", async (ctx) => {
+  const body = await ctx.request.json();
+
+  return {
+    id: ctx.params.id,
+    ...body,
+    updatedAt: new Date().toISOString(),
+  };
+});
+
+/**
+ * Delete a resource
+ * DELETE /resources/:id
+ */
+app.delete("/resources/:id", (ctx) => {
+  return {
+    message: `Resource ${ctx.params.id} deleted`,
+    deletedAt: new Date().toISOString(),
+  };
+});
+
+// ============================================================================
+// Server Start
+// ============================================================================
+
+const port = parseInt(env("PORT", "3000"), 10);
+
+const server = app.listen(port);
+
+console.log(`
+🚀 Bunary Basic API Example
+
+Server running at http://localhost:${server.port}
+
+Available endpoints:
+  GET  /           - Welcome message
+  GET  /health     - Health check
+  GET  /users/:id  - Get user by ID
+  GET  /users/:userId/posts/:postId - Get post
+  GET  /items?page=1&limit=10       - List items with pagination
+  POST /resources  - Create resource
+  PUT  /resources/:id - Update resource
+  DELETE /resources/:id - Delete resource
+
+Environment: ${isDev() ? "development" : "production"}
+`);


### PR DESCRIPTION
## Summary

Add a basic API example demonstrating all core Bunary framework features.

## Features Demonstrated

- ✅ Route definition with `createApp()`
- ✅ Path parameters (`:id` syntax)
- ✅ Multiple path parameters
- ✅ Query parameters with pagination
- ✅ JSON serialization (automatic for objects)
- ✅ Middleware pipeline (logging middleware)
- ✅ Environment helpers (`env()`, `isDev()`)
- ✅ All HTTP methods (GET, POST, PUT, DELETE)

## Files

- `basic-api/package.json` - Dependencies on @bunary/core and @bunary/http
- `basic-api/bunary.config.ts` - Configuration with defineConfig
- `basic-api/src/index.ts` - Complete working API server
- `basic-api/README.md` - Documentation with curl examples

## Testing

```bash
cd basic-api
bun install
bun src/index.ts

# In another terminal
curl http://localhost:3000/
curl http://localhost:3000/health
curl http://localhost:3000/users/42
curl "http://localhost:3000/items?page=2&limit=3"
```

Closes #1