### PR TITLE
chore(basic-api): upgrade to current @bunary/*

### DIFF
--- a/basic-api/README.md
+++ b/basic-api/README.md
@@ -83,18 +83,7 @@ basic-api/
 
 ## Configuration
 
-The `bunary.config.ts` file uses `defineConfig()` for type-safe configuration:
-
-```typescript
-import { defineConfig } from "@bunary/core";
-
-export default defineConfig({
-  app: {
-    name: "basic-api",
-    env: "development",
-  },
-});
-```
+The `bunary.config.ts` file uses `defineConfig()` from `@bunary/core` for type-safe configuration. The server is started with `app.listen({ port })` (options form supported by `@bunary/http`).
 
 ## Environment Variables
 

--- a/basic-api/bun.lock
+++ b/basic-api/bun.lock
@@ -5,18 +5,19 @@
     "": {
       "name": "basic-api",
       "dependencies": {
-        "@bunary/core": "^0.0.5",
-        "@bunary/http": "^0.0.4",
+        "@bunary/core": "^0.0.7",
+        "@bunary/http": "^0.0.11",
       },
       "devDependencies": {
         "@types/bun": "^1.3.6",
+        "bun-types": "latest",
       },
     },
   },
   "packages": {
-    "@bunary/core": ["@bunary/core@0.0.5", "", {}, "sha512-gHypUYkU2WMOAYW6oYZpmowG7hVte3Ol6WLoSET1Z1uB7tS7SMOb2uscyL05CydYNiHLHIkdV5Pzg+tEvo6U8g=="],
+    "@bunary/core": ["@bunary/core@0.0.7", "", {}, "sha512-d91UxxvYh+gZmzxSIiRg73R7YGpMztGt7+XuUZiWzaiJMr5LY26TU8bGiyK7rqBcqrhdf2t9h/qbroaxd3t/Ug=="],
 
-    "@bunary/http": ["@bunary/http@0.0.4", "", { "dependencies": { "@bunary/core": "^0.0.2" } }, "sha512-KTh550X0gab4pBX/3h/8r7JLgMiFAE3ppgLqACuKeyfbTk9mmSHoQUA5OXBczrGxKzW45Wzp5lsFsPCSrXvGew=="],
+    "@bunary/http": ["@bunary/http@0.0.11", "", {}, "sha512-SEH0FeeMJBcBZFHmr/rdb+HQ2kp1SK1hf2LoiEqeh/JP0Yi1n/6GCIZRD3wfUZnLJtm4RPFdNx3yDPOneKSzAA=="],
 
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
@@ -25,7 +26,5 @@
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@bunary/http/@bunary/core": ["@bunary/core@0.0.2", "", {}, "sha512-fBJMKV1pjrVMXa/ndRehmX/cXQd71b37YGSXQ3p2DDyynvP7EDtYlWJ3V4KQa3jIC/OeYCKmjopcXDHS/IMN7Q=="],
   }
 }

--- a/basic-api/package.json
+++ b/basic-api/package.json
@@ -10,10 +10,11 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@bunary/core": "^0.0.5",
-    "@bunary/http": "^0.0.4"
+    "@bunary/core": "^0.0.7",
+    "@bunary/http": "^0.0.11"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.6"
+    "@types/bun": "^1.3.6",
+    "bun-types": "latest"
   }
 }

--- a/basic-api/src/index.ts
+++ b/basic-api/src/index.ts
@@ -204,7 +204,7 @@ app.delete("/resources/:id", (ctx) => {
 
 const port = parseInt(env("PORT", "3000"), 10);
 
-const server = app.listen(port);
+const server = app.listen({ port });
 
 console.log(`
 🚀 Bunary Basic API Example


### PR DESCRIPTION
Closes #16

- Bump @bunary/core to ^0.0.7, @bunary/http to ^0.0.11
- Use `app.listen({ port })` options form in src and tests
- README: note listen options API