### PR TITLE
chore(nested-routes): upgrade to current @bunary/*

### DIFF
--- a/nested-routes/bun.lock
+++ b/nested-routes/bun.lock
@@ -5,14 +5,25 @@
     "": {
       "name": "nested-routes-example",
       "dependencies": {
-        "@bunary/core": "^0.0.2",
-        "@bunary/http": "^0.0.2",
+        "@bunary/core": "^0.0.7",
+        "@bunary/http": "^0.0.11",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.6",
       },
     },
   },
   "packages": {
-    "@bunary/core": ["@bunary/core@0.0.2", "", {}, "sha512-fBJMKV1pjrVMXa/ndRehmX/cXQd71b37YGSXQ3p2DDyynvP7EDtYlWJ3V4KQa3jIC/OeYCKmjopcXDHS/IMN7Q=="],
+    "@bunary/core": ["@bunary/core@0.0.7", "", {}, "sha512-d91UxxvYh+gZmzxSIiRg73R7YGpMztGt7+XuUZiWzaiJMr5LY26TU8bGiyK7rqBcqrhdf2t9h/qbroaxd3t/Ug=="],
 
-    "@bunary/http": ["@bunary/http@0.0.2", "", { "dependencies": { "@bunary/core": "^0.0.2" } }, "sha512-/6kS8PCaNXYMSE6NCFG2fKFY+4jCco7WGDk4Dw6jHssZfkLvlhOeeQAavqcFLkcRmQfIG4ALH77tG9V4va3RmA=="],
+    "@bunary/http": ["@bunary/http@0.0.11", "", {}, "sha512-SEH0FeeMJBcBZFHmr/rdb+HQ2kp1SK1hf2LoiEqeh/JP0Yi1n/6GCIZRD3wfUZnLJtm4RPFdNx3yDPOneKSzAA=="],
+
+    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+
+    "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
+
+    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/nested-routes/package.json
+++ b/nested-routes/package.json
@@ -9,8 +9,8 @@
 		"test": "bun test"
 	},
 	"dependencies": {
-        "@bunary/core": "^0.0.5",
-        "@bunary/http": "^0.0.4"
+        "@bunary/core": "^0.0.7",
+        "@bunary/http": "^0.0.11"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.6"

--- a/nested-routes/src/index.ts
+++ b/nested-routes/src/index.ts
@@ -35,7 +35,8 @@ app.get("/", () => ({
 registerRoutes(app);
 
 // Start server
-const server = app.listen(3000);
+const port = 3000;
+const server = app.listen({ port });
 console.log(`🚀 Server running on http://localhost:${server.port}`);
 console.log(`
 Try these endpoints:

--- a/nested-routes/tests/api.test.ts
+++ b/nested-routes/tests/api.test.ts
@@ -11,7 +11,7 @@ import { registerRoutes } from "../src/routes/index.js";
 
 describe("Nested Routes Example", () => {
 	let app: ReturnType<typeof createApp>;
-	let server: ReturnType<typeof createApp["listen"]>;
+	let server: ReturnType<ReturnType<typeof createApp>["listen"]>;
 	let baseUrl: string;
 
 	beforeAll(() => {
@@ -30,7 +30,7 @@ describe("Nested Routes Example", () => {
 
 		// Start server on a random port for testing
 		const port = 0; // 0 = random available port
-		server = app.listen(port);
+		server = app.listen({ port });
 		baseUrl = `http://localhost:${server.port}`;
 	});
 


### PR DESCRIPTION
Closes #17

## Changes

- Upgrade `@bunary/core` from `^0.0.5` to `^0.0.7`
- Upgrade `@bunary/http` from `^0.0.4` to `^0.0.11`
- Update `app.listen()` to use object form: `app.listen({ port })`
- Update tests to use object form: `app.listen({ port: 0 })`

## Testing

- ✅ All 22 tests pass
- ✅ Verified route organization, CRUD operations, query parameters
- ✅ Confirmed compatibility with current framework APIs