### PR TITLE
fix(basic-api): remove redundant bun-types devDependency

### DIFF
--- a/basic-api/bun.lock
+++ b/basic-api/bun.lock
@@ -10,7 +10,6 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.6",
-        "bun-types": "latest",
       },
     },
   },

--- a/basic-api/package.json
+++ b/basic-api/package.json
@@ -14,7 +14,6 @@
     "@bunary/http": "^0.0.11"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.6",
-    "bun-types": "latest"
+    "@types/bun": "^1.3.6"
   }
 }


### PR DESCRIPTION
Closes #21

## Summary

- Remove redundant `bun-types: "latest"` from basic-api devDependencies
- `@types/bun` already includes bun-types as a transitive dependency
- Using "latest" as version can lead to inconsistent builds
- Now consistent with nested-routes (which only uses `@types/bun`)

## Testing

- ✅ All 16 tests pass
- ✅ `bun install` succeeds with updated lockfile