### PR TITLE
chore(basic-orm): upgrade to current @bunary/*

### DIFF
--- a/basic-orm/bun.lock
+++ b/basic-orm/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "basic-orm",
       "dependencies": {
-        "@bunary/core": "^0.0.5",
-        "@bunary/orm": "^0.0.5",
+        "@bunary/core": "^0.0.7",
+        "@bunary/orm": "^0.0.14",
       },
       "devDependencies": {
         "@types/bun": "^1.3.6",
@@ -14,9 +14,9 @@
     },
   },
   "packages": {
-    "@bunary/core": ["@bunary/core@0.0.5", "", {}, "sha512-gHypUYkU2WMOAYW6oYZpmowG7hVte3Ol6WLoSET1Z1uB7tS7SMOb2uscyL05CydYNiHLHIkdV5Pzg+tEvo6U8g=="],
+    "@bunary/core": ["@bunary/core@0.0.7", "", {}, "sha512-d91UxxvYh+gZmzxSIiRg73R7YGpMztGt7+XuUZiWzaiJMr5LY26TU8bGiyK7rqBcqrhdf2t9h/qbroaxd3t/Ug=="],
 
-    "@bunary/orm": ["@bunary/orm@0.0.5", "", { "dependencies": { "@bunary/core": "^0.0.2" } }, "sha512-Dxq4QlQaE4fnJ45efaYMxXTd3HQlqRNrqgKTnor0pT2Io6grMwB6CW+GsiBZRO2gJzcIIIyODERa707GXkEi6Q=="],
+    "@bunary/orm": ["@bunary/orm@0.0.14", "", { "peerDependencies": { "@bunary/core": "^0.0.7" } }, "sha512-yAMI+/z9tXWsDwfYQD30cjaEtDQnuovakAvdZrN2nrluCaFXK7iynImth3FSSCFY8evFxnU84btPaWBm+FZJJQ=="],
 
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
@@ -25,7 +25,5 @@
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "@bunary/orm/@bunary/core": ["@bunary/core@0.0.2", "", {}, "sha512-fBJMKV1pjrVMXa/ndRehmX/cXQd71b37YGSXQ3p2DDyynvP7EDtYlWJ3V4KQa3jIC/OeYCKmjopcXDHS/IMN7Q=="],
   }
 }

--- a/basic-orm/package.json
+++ b/basic-orm/package.json
@@ -10,8 +10,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@bunary/core": "^0.0.5",
-    "@bunary/orm": "^0.0.5"
+    "@bunary/core": "^0.0.7",
+    "@bunary/orm": "^0.0.14"
   },
   "devDependencies": {
     "@types/bun": "^1.3.6"

--- a/basic-orm/tests/orm.test.ts
+++ b/basic-orm/tests/orm.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, beforeAll, afterAll } from "bun:test";
 import { Database } from "bun:sqlite";
-import { defineConfig, clearBunaryConfig } from "@bunary/core";
+import { setOrmConfig, resetDriver } from "@bunary/orm";
 import { Users, Posts } from "../src/models/index.js";
 
 describe("Basic ORM Example", () => {
@@ -17,19 +17,12 @@ describe("Basic ORM Example", () => {
 		// Create a temporary test database
 		testDbPath = `/tmp/bunary-basic-orm-test-${Date.now()}.sqlite`;
 
-		// Configure Bunary with test database
-		defineConfig({
-			app: {
-				name: "Basic ORM Example Test",
-				env: "test",
-				debug: false,
-			},
-			orm: {
-				database: {
-					type: "sqlite",
-					sqlite: {
-						path: testDbPath,
-					},
+		// Configure ORM with test database
+		setOrmConfig({
+			database: {
+				type: "sqlite",
+				sqlite: {
+					path: testDbPath,
 				},
 			},
 		});
@@ -90,15 +83,13 @@ describe("Basic ORM Example", () => {
 	});
 
 	afterAll(async () => {
-		// Clean up test database
+		// Clean up driver and test database
 		try {
-			const db = new Database(testDbPath);
-			db.close();
+			resetDriver();
 			await Bun.file(testDbPath).unlink();
 		} catch {
 			// Ignore cleanup errors
 		}
-		clearBunaryConfig();
 	});
 
 	describe("Basic Queries", () => {


### PR DESCRIPTION
Closes #18

## Changes

- Upgrade `@bunary/core` from `^0.0.5` to `^0.0.7`
- Upgrade `@bunary/orm` from `^0.0.5` to `^0.0.14`
- Update test file to use `setOrmConfig` and `resetDriver` from `@bunary/orm` directly (API change in newer ORM versions)

## Testing

- ✅ All 31 tests pass
- ✅ Verified model queries, protected fields, timestamps, and method chaining
- ✅ Confirmed compatibility with current framework APIs