### PR TITLE
fix(basic-orm): add missing config directory

### DIFF
--- a/basic-orm/src/config/app.ts
+++ b/basic-orm/src/config/app.ts
@@ -1,0 +1,14 @@
+/**
+ * Application Configuration
+ *
+ * Main app configuration using @bunary/core
+ */
+import { defineConfig } from "@bunary/core";
+
+export default defineConfig({
+	app: {
+		name: "Basic ORM Example",
+		env: "development",
+		debug: true,
+	},
+});

--- a/basic-orm/src/config/orm.ts
+++ b/basic-orm/src/config/orm.ts
@@ -1,0 +1,20 @@
+/**
+ * ORM Configuration
+ *
+ * Database configuration for @bunary/orm
+ */
+import { defineOrmConfig } from "@bunary/orm";
+
+const dbPath = "./example.sqlite";
+
+export default defineOrmConfig({
+	database: {
+		type: "sqlite",
+		sqlite: {
+			path: dbPath,
+		},
+	},
+});
+
+// Export dbPath for use in database initialization
+export { dbPath };


### PR DESCRIPTION
Closes #24

## Summary

The basic-orm example imports config files that were never committed to the repository. Without these files, the example fails to run after cloning.

## Changes

- Add `basic-orm/src/config/app.ts` - App configuration using `defineConfig` from `@bunary/core`
- Add `basic-orm/src/config/orm.ts` - ORM configuration using `defineOrmConfig` from `@bunary/orm`

## Files Added

```
basic-orm/src/config/
├── app.ts   # App name, env, debug settings
└── orm.ts   # SQLite database path configuration
```