### PR TITLE
ci: add release tag workflow on merge to main

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
 jobs:
   tag:
     runs-on: ubuntu-latest
@@ -14,14 +18,32 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get version from package.json
+      - name: Get and validate version from package.json
         id: version
-        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [ -z "$VERSION" ]; then
+            echo "::error::package.json version is empty"
+            exit 1
+          fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
+            echo "::error::Invalid semver format: $VERSION. Expected x.y.z or x.y.z-prerelease"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag already exists
+        run: |
+          TAG="v${{ steps.version.outputs.VERSION }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists. Bump the version in package.json before merging."
+            exit 1
+          fi
 
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           TAG="v${{ steps.version.outputs.VERSION }}"
-          git tag -f "$TAG" ${{ github.sha }}
-          git push origin "$TAG" --force
+          git tag "$TAG" ${{ github.sha }}
+          git push origin "$TAG"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,27 @@
+name: Tag release on main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from package.json
+        id: version
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="v${{ steps.version.outputs.VERSION }}"
+          git tag -f "$TAG" ${{ github.sha }}
+          git push origin "$TAG" --force

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bunary-examples",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Example projects for the Bunary framework"
+}


### PR DESCRIPTION
Closes #28

## Summary

Add a GitHub workflow that creates a git tag when changes are merged to main. Use this as a **base test** before rolling out to package repos (core, auth, cli, http, orm).

## Changes

- Add `.github/workflows/tag-release.yml` — triggers on push to main, reads version from `package.json`, creates/pushes tag `v{version}`
- Add root `package.json` — required for workflow to read version (examples is a monorepo; previously had no root package.json)

## Root package.json

```json
{
  "name": "bunary-examples",
  "version": "0.1.0",
  "private": true,
  "description": "Example projects for the Bunary framework"
}
```

## Workflow behavior

1. Triggered on push to `main`
2. Reads `version` from root `package.json` (e.g. `0.1.0`)
3. Creates tag `v0.1.0` at current HEAD
4. Pushes tag to origin (uses `--force` to update tag if version unchanged)